### PR TITLE
Update open_external_editor.gd to fit 3.1.1 stable

### DIFF
--- a/open_external_editor.gd
+++ b/open_external_editor.gd
@@ -99,7 +99,7 @@ func get_text_edit():
             if godot_version["minor"] == 0:
                 return editor.get_child(1)
             else:
-                return editor.get_child(0).get_child(1)
+                return editor.get_child(0).get_child(0)
         i += 1
 
 func parse_exec_flags(flags):


### PR DESCRIPTION
try to change hacky code to fit godot 3.1.1 stable...
tested on my godot 3.1.1 stable...

BUT I think this tricky way to get TextEditor will bring more headache when godot itself upgrades, is there any more elegant solution?