### PR TITLE
Added compatibility with Godot 3.2+

### DIFF
--- a/open_external_editor.gd
+++ b/open_external_editor.gd
@@ -99,7 +99,9 @@ func get_text_edit():
             if godot_version["minor"] == 0:
                 return editor.get_child(1)
             else:
-                return editor.get_child(0).get_child(1)
+                for child in editor.get_child(0).get_children():
+                    if child.name == "TextEdit":
+                        return child
         i += 1
 
 func parse_exec_flags(flags):


### PR DESCRIPTION
Removed the hard coded index with a loop through all the children of the editor, thus making it compatible with Godot 3.2, and hopefully, future versions.